### PR TITLE
Support npm v3 installed dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '5.2'
   - '0.12'
   - '0.10'

--- a/config/gulp.js
+++ b/config/gulp.js
@@ -55,8 +55,8 @@ gulp.task('build', (callback) => {
   runSequence('clean-dist', 'transpile', callback);
 });
 
-gulp.task('test', [ 'mocha' ]);
+gulp.task('test', [ 'lint', 'mocha' ]);
 
 gulp.task('default', (callback) => {
-  runSequence('build', 'lint', 'test', callback);
+  runSequence('build', 'test', callback);
 });

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -92,7 +92,7 @@ var generateDependencyList = function generateDependencyList(dependencySources) 
   var npmshrinkwrapSpecificDependencies = _underscore2['default'].difference(npmshrinkwrapDependenciesList, packagejsonDependenciesList);
   dependencies = dependencies.concat(_underscore2['default'].map(npmshrinkwrapSpecificDependencies, _underscore2['default'].partial(generateDependencyObject, dependencySources)));
 
-  var installedSpecificDependencies = _underscore2['default'].difference(installedDependenciesList, packagejsonDependenciesList);
+  var installedSpecificDependencies = _underscore2['default'].difference(packagejsonDependenciesList, installedDependenciesList);
   dependencies = dependencies.concat(_underscore2['default'].map(installedSpecificDependencies, _underscore2['default'].partial(generateDependencyObject, dependencySources)));
 
   dependencies = _underscore2['default'].sortBy(dependencies, 'name');

--- a/package.json
+++ b/package.json
@@ -38,27 +38,27 @@
   "dependencies": {
     "npm": "~2.14.2",
     "promise": "~7.0.4",
-    "semver": "~5.0.1",
+    "semver": "~5.1.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {
     "babel": "~5.8.23",
     "babel-core": "~5.8.23",
     "babel-eslint": "~4.1.1",
-    "chai": "~3.2.0",
-    "del": "~2.0.1",
-    "eslint": "~1.3.1",
+    "chai": "~3.4.1",
+    "del": "~2.2.0",
+    "eslint": "~1.10.3",
     "gulp": "~3.9.0",
     "gulp-babel": "~5.2.1",
-    "gulp-eslint": "~1.0.0",
+    "gulp-eslint": "~1.1.1",
     "gulp-lint-filepath": "~1.0.1",
-    "gulp-load-plugins": "~0.10.0",
-    "gulp-mocha": "~2.1.3",
-    "npm-check": "~4.0.1",
-    "proxyquire": "~1.7.1",
-    "run-sequence": "~1.1.2",
-    "sinon": "~1.16.1",
+    "gulp-load-plugins": "~1.1.0",
+    "gulp-mocha": "~2.2.0",
+    "npm-check": "~4.1.3",
+    "proxyquire": "~1.7.3",
+    "run-sequence": "~1.1.5",
+    "sinon": "~1.17.2",
     "sinon-chai": "~2.8.0",
-    "vinyl-paths": "~2.0.0"
+    "vinyl-paths": "~2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-dependency-lists",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Check dependency lists are all in sync",
   "author": "Alistair Brown <npm@alistairjcbrown.com> (http://alistairjcbrown.com/)",
   "main": "index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,7 +64,7 @@ const generateDependencyList = (dependencySources) => {
   const npmshrinkwrapSpecificDependencies = _.difference(npmshrinkwrapDependenciesList, packagejsonDependenciesList);
   dependencies = dependencies.concat(_.map(npmshrinkwrapSpecificDependencies, _.partial(generateDependencyObject, dependencySources)));
 
-  const installedSpecificDependencies = _.difference(installedDependenciesList, packagejsonDependenciesList);
+  const installedSpecificDependencies = _.difference(packagejsonDependenciesList, installedDependenciesList);
   dependencies = dependencies.concat(_.map(installedSpecificDependencies, _.partial(generateDependencyObject, dependencySources)));
 
   dependencies = _.sortBy(dependencies, 'name');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,6 @@ describe('Check Dependency Lists', function() {
 
   describe('error conditions', function() {
     let errorStates = {
-      'install-mismatch': 'has only been installed',
       'package-mismatch': 'has only been saved to package.json',
       'shrinkwrap-mismatch': 'has only been saved to npm-shrinkwrap.json',
       'version-mismatch': 'has a version which differes from the package.json'
@@ -100,18 +99,25 @@ describe('Check Dependency Lists', function() {
     });
   });
 
-  describe('success condition', function() {
-    describe('when there are no dependency mismatches', function() {
-      beforeEach(function(done) {
-        env.installed = require('./fixtures/no-mismatch/installed.json');
-        env.checkDependencyLists({
-          rootDir: 'test/fixtures/no-mismatch',
-          callback: done
-        });
-      });
+  describe('success conditions', function() {
+    let successStates = {
+      'install-mismatch': 'only install mismatches',
+      'no-mismatch': 'no dependency mismatches'
+    };
 
-      it('should output nothing', function() {
-        expect(mockedLogger.error).to.have.callCount(0);
+    _.each(successStates, (description, mismatchType) => {
+      describe(`when there are ${description}`, function() {
+        beforeEach(function(done) {
+          env.installed = require(`./fixtures/${mismatchType}/installed.json`);
+          env.checkDependencyLists({
+            rootDir: `test/fixtures/${mismatchType}`,
+            callback: done
+          });
+        });
+
+        it('should output nothing', function() {
+          expect(mockedLogger.error).to.have.callCount(0);
+        });
       });
     });
   });


### PR DESCRIPTION
npm v3 will automatically flatten the dependencies in `node_modules` directory as part of its deduplication. Therefore, when checking that the install dependencies in the `node_modules` directory match those in the `package.json` file, there will be a mismatch.

This update allows "extraneous" installed dependencies to be allowed, only flagging as an issue if the install is missing.

It also updates development dependencies and adds node v5.2.0 as a CI build environment.
